### PR TITLE
Reduced data loading

### DIFF
--- a/Namo.Plugin.InPlayerEpisodePreview/Api/DTOs/EpisodeDescriptionDto.cs
+++ b/Namo.Plugin.InPlayerEpisodePreview/Api/DTOs/EpisodeDescriptionDto.cs
@@ -1,0 +1,3 @@
+﻿namespace Namo.Plugin.InPlayerEpisodePreview.Api.DTOs;
+
+public record EpisodeDescriptionDto(string Description);

--- a/Namo.Plugin.InPlayerEpisodePreview/Api/InPlayerPreviewController.cs
+++ b/Namo.Plugin.InPlayerEpisodePreview/Api/InPlayerPreviewController.cs
@@ -11,6 +11,7 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Persistence;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Session;
+using Namo.Plugin.InPlayerEpisodePreview.Api.DTOs;
 using Namo.Plugin.InPlayerEpisodePreview.Configuration;
 
 namespace Namo.Plugin.InPlayerEpisodePreview.Api;
@@ -108,8 +109,9 @@ public class InPlayerPreviewController : ControllerBase
         BaseItem? item = _libraryManager.GetItemById(id);
         if (item is null)
         {
-            _logger.LogInformation("Couldn't find item to play");
-            return NotFound("Couldn't find item to play");
+            const string message = "Couldn't find item to play";
+            _logger.LogInformation(message);
+            return NotFound(message);
         }
         
         _sessionManager.SendPlayCommand(session.Id, session.Id, 
@@ -121,5 +123,21 @@ public class InPlayerPreviewController : ControllerBase
             }, CancellationToken.None);
         
         return Ok();
+    }
+    
+    [HttpGet("Items/{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public ActionResult GetMediaDescription([FromRoute] Guid id)
+    {
+        BaseItem? item = _libraryManager.GetItemById(id);
+        if (item is not null) 
+            return new OkObjectResult(new EpisodeDescriptionDto(item.Overview));
+        
+        // Error case
+        const string message = "Couldn't find item to play";
+        _logger.LogInformation(message);
+        return NotFound(message);
+
     }
 }

--- a/Namo.Plugin.InPlayerEpisodePreview/Web/Endpoints.ts
+++ b/Namo.Plugin.InPlayerEpisodePreview/Web/Endpoints.ts
@@ -1,5 +1,6 @@
 export class Endpoints {
     public static readonly BASE: string = "InPlayerPreview";
     public static readonly EPISODE_INFO: string = "/Users/{userId}/Items/{episodeId}";
+    public static readonly EPISODE_DESCRIPTION: string = "/Items/{episodeId}";
     public static readonly PLAY_MEDIA: string = "/Users/{userId}/Items/{episodeId}/Play/{ticks}";
 }

--- a/Namo.Plugin.InPlayerEpisodePreview/Web/InPlayerPreview.ts
+++ b/Namo.Plugin.InPlayerEpisodePreview/Web/InPlayerPreview.ts
@@ -34,7 +34,7 @@ document?.head?.appendChild(inPlayerPreviewStyle);
 const logger: Logger = new Logger();
 const authService: AuthService = new AuthService();
 const programDataStore: ProgramDataStore = new ProgramDataStore();
-const dataLoader: DataLoader = new DataLoader(authService, programDataStore);
+const dataLoader: DataLoader = new DataLoader(authService);
 new DataFetcher(programDataStore, dataLoader, authService, logger)
 let playbackHandler: PlaybackHandler = new PlaybackHandler(programDataStore, logger);
 

--- a/Namo.Plugin.InPlayerEpisodePreview/Web/ListElementFactory.ts
+++ b/Namo.Plugin.InPlayerEpisodePreview/Web/ListElementFactory.ts
@@ -29,6 +29,7 @@ export class ListElementFactory {
                 if (!episodes[i].Description) {
                     const request = this.dataLoader.loadEpisodeDescription(episodes[i].Id, () => {
                         episodes[i].Description = request.response?.Description;
+                        this.programDataStore.updateEpisode(episodes[i]);
                         episodeContainer.querySelector('.previewEpisodeDescription').textContent = episodes[i].Description;
                     });
                 }
@@ -43,11 +44,15 @@ export class ListElementFactory {
 
             if (episodes[i].Id === this.programDataStore.activeMediaSourceId) {
                 const episodeNode = document.querySelector(`[data-id="${episodes[i].IndexNumber}"]`).querySelector('.previewListItemContent');
+                
                 // preload episode description for the currently playing episode
-                const request = this.dataLoader.loadEpisodeDescription(episodes[i].Id, () => {
-                    episodes[i].Description = request.response?.Description;
-                    episodeNode.querySelector('.previewEpisodeDescription').textContent = episodes[i].Description;
-                });
+                if (!episodes[i].Description) {
+                    const request = this.dataLoader.loadEpisodeDescription(episodes[i].Id, () => {
+                        episodes[i].Description = request.response?.Description;
+                        this.programDataStore.updateEpisode(episodes[i]);
+                        episodeNode.querySelector('.previewEpisodeDescription').textContent = episodes[i].Description;
+                    });
+                }
                 
                 episodeNode.classList.remove('hide');
                 episodeNode.classList.add('selectedListItem');

--- a/Namo.Plugin.InPlayerEpisodePreview/Web/ListElementFactory.ts
+++ b/Namo.Plugin.InPlayerEpisodePreview/Web/ListElementFactory.ts
@@ -39,7 +39,7 @@ export class ListElementFactory {
                 episodeContainer.classList.add('selectedListItem');
                 
                 // scroll to the selected episode
-                episodeContainer.scrollIntoView({ block: "end" });
+                episodeContainer.parentElement.scrollIntoView({ block: "start" });
             });
 
             if (episodes[i].Id === this.programDataStore.activeMediaSourceId) {

--- a/Namo.Plugin.InPlayerEpisodePreview/Web/ListElementFactory.ts
+++ b/Namo.Plugin.InPlayerEpisodePreview/Web/ListElementFactory.ts
@@ -13,7 +13,7 @@ export class ListElementFactory {
     
     public createEpisodeElements(episodes: Episode[], parentDiv: HTMLElement) {
         for (let i = 0; i < episodes.length; i++) {
-            let episode = new EpisodeElementTemplate(parentDiv, i, episodes[i], this.dataLoader, this.playbackHandler, this.programDataStore);
+            const episode = new EpisodeElementTemplate(parentDiv, i, episodes[i], this.dataLoader, this.playbackHandler, this.programDataStore);
             episode.render((e: MouseEvent) => {
                 e.stopPropagation();
                 
@@ -22,9 +22,18 @@ export class ListElementFactory {
                     element.classList.add('hide');
                     element.classList.remove('selectedListItem');
                 });
-
+                
+                const episodeContainer = document.querySelector(`[data-id="${episodes[i].IndexNumber}"]`).querySelector('.previewListItemContent');
+                
+                // load episode description
+                if (!episodes[i].Description) {
+                    const request = this.dataLoader.loadEpisodeDescription(episodes[i].Id, () => {
+                        episodes[i].Description = request.response?.Description;
+                        episodeContainer.querySelector('.previewEpisodeDescription').textContent = episodes[i].Description;
+                    });
+                }
+                
                 // show episode content for the selected episode
-                let episodeContainer = document.querySelector(`[data-id="${episodes[i].IndexNumber}"]`).querySelector('.previewListItemContent');
                 episodeContainer.classList.remove('hide');
                 episodeContainer.classList.add('selectedListItem');
                 
@@ -33,7 +42,13 @@ export class ListElementFactory {
             });
 
             if (episodes[i].Id === this.programDataStore.activeMediaSourceId) {
-                let episodeNode = document.querySelector(`[data-id="${episodes[i].IndexNumber}"]`).querySelector('.previewListItemContent');
+                const episodeNode = document.querySelector(`[data-id="${episodes[i].IndexNumber}"]`).querySelector('.previewListItemContent');
+                // preload episode description for the currently playing episode
+                const request = this.dataLoader.loadEpisodeDescription(episodes[i].Id, () => {
+                    episodes[i].Description = request.response?.Description;
+                    episodeNode.querySelector('.previewEpisodeDescription').textContent = episodes[i].Description;
+                });
+                
                 episodeNode.classList.remove('hide');
                 episodeNode.classList.add('selectedListItem');
             }
@@ -42,7 +57,7 @@ export class ListElementFactory {
     
     public createSeasonElements(seasons: Season[], parentDiv: HTMLElement, currentSeasonIndex: number, titleContainer: PopupTitleTemplate) {
         for (let i = 0; i < seasons.length; i++) {
-            let season = new SeasonListElementTemplate(parentDiv, i, seasons[i], i === currentSeasonIndex);
+            const season = new SeasonListElementTemplate(parentDiv, i, seasons[i], i === currentSeasonIndex);
             season.render((e: MouseEvent) => {
                 e.stopPropagation();
                 

--- a/Namo.Plugin.InPlayerEpisodePreview/Web/Services/DataFetcher.ts
+++ b/Namo.Plugin.InPlayerEpisodePreview/Web/Services/DataFetcher.ts
@@ -81,7 +81,7 @@ export class DataFetcher {
 
         let seasons: Season[] = [];
         let iterator = seasonIds.values();
-        let value: IteratorResult<string, any> = iterator.next();
+        let value: IteratorResult<string> = iterator.next();
         while (!value.done) {
             let seasonId = value.value;
             let season: Season = {
@@ -93,7 +93,7 @@ export class DataFetcher {
             season.episodes.map((episode: Episode) => {
                 let request = this.dataLoader.loadEpisodeDescription(episode.Id, () => {});
                 request.onloadend = () => {
-                    episode.Description = request.response.Overview;
+                    episode.Description = request.response?.Description;
                 };
                 
                 return episode;

--- a/Namo.Plugin.InPlayerEpisodePreview/Web/Services/DataFetcher.ts
+++ b/Namo.Plugin.InPlayerEpisodePreview/Web/Services/DataFetcher.ts
@@ -90,14 +90,6 @@ export class DataFetcher {
                 episodes: group[seasonId]
             };
             
-            season.episodes.map((episode: Episode) => {
-                let request = this.dataLoader.loadEpisodeDescription(episode.Id, () => {});
-                request.onloadend = () => {
-                    episode.Description = request.response?.Description;
-                };
-                
-                return episode;
-            });
             season.episodes.sort((a: Episode, b: Episode) => a.IndexNumber - b.IndexNumber);
             
             seasons.push(season);
@@ -106,6 +98,7 @@ export class DataFetcher {
             
             value = iterator.next();
         }
+
         this.programDataStore.seasons = seasons;
         
         function groupBy<T>(arr: T[], fn: (item: T) => any) {

--- a/Namo.Plugin.InPlayerEpisodePreview/Web/Services/DataLoader.ts
+++ b/Namo.Plugin.InPlayerEpisodePreview/Web/Services/DataLoader.ts
@@ -1,12 +1,11 @@
 ﻿import {AuthService} from "./AuthService";
-import {ProgramDataStore} from "./ProgramDataStore";
 import {Endpoints} from "../Endpoints";
 
 export class DataLoader {
-    constructor(protected authService: AuthService, protected programDataStore: ProgramDataStore) {
+    constructor(protected authService: AuthService) {
     }
 
-    public loadEpisodeDescription(episodeId: string, onloadend: Function): XMLHttpRequest {
+    public loadEpisodeDescription(episodeId: string, onloadend: (this: XMLHttpRequest, ev: ProgressEvent<EventTarget>) => void): XMLHttpRequest {
         let requestUrl = `../${Endpoints.BASE}${Endpoints.EPISODE_DESCRIPTION}`
             .replace('{episodeId}', episodeId);
 
@@ -16,7 +15,7 @@ export class DataLoader {
         episodeDescriptionRequest.open('GET', requestUrl);
         this.authService.addAuthHeaderIntoHttpRequest(episodeDescriptionRequest);
         episodeDescriptionRequest.send();
-        episodeDescriptionRequest.onloadend = () => onloadend();
+        episodeDescriptionRequest.onloadend = onloadend;
 
         return episodeDescriptionRequest;
     }

--- a/Namo.Plugin.InPlayerEpisodePreview/Web/Services/DataLoader.ts
+++ b/Namo.Plugin.InPlayerEpisodePreview/Web/Services/DataLoader.ts
@@ -7,8 +7,7 @@ export class DataLoader {
     }
 
     public loadEpisodeDescription(episodeId: string, onloadend: Function): XMLHttpRequest {
-        let requestUrl = Endpoints.EPISODE_INFO
-            .replace('{userId}', this.programDataStore.userId)
+        let requestUrl = `../${Endpoints.BASE}${Endpoints.EPISODE_DESCRIPTION}`
             .replace('{episodeId}', episodeId);
 
         let episodeDescriptionRequest = new XMLHttpRequest();


### PR DESCRIPTION
Data usage updates:
- Data will only be loaded if needed (opening an episode element)
- Additional data: only load the episode description instead of whole episode object

Other updates:
- Set autoscroll on opening episodes to the top instead of bottom

This PR should fix errors like #25 on slow connections