### PR TITLE
Fix: Incorrectly fetched activeMediaSourceId

### DIFF
--- a/Namo.Plugin.InPlayerEpisodePreview/InPlayerEpisodePreviewPlugin.cs
+++ b/Namo.Plugin.InPlayerEpisodePreview/InPlayerEpisodePreviewPlugin.cs
@@ -69,7 +69,7 @@ public class InPlayerEpisodePreviewPlugin : BasePlugin<PluginConfiguration>, IHa
         string scriptReplace = "<script plugin=\"InPlayerEpisodePreview\".*?></script>";
         string scriptElement =
             string.Format(
-                "<script plugin=\"InPlayerEpisodePreview\" version=\"1.3.0.0\" src=\"{0}/InPlayerPreview/ClientScript\"></script>",
+                "<script plugin=\"InPlayerEpisodePreview\" version=\"1.3.1.0\" src=\"{0}/InPlayerPreview/ClientScript\"></script>",
                 basePath);
 
         if (!indexContents.Contains(scriptElement))

--- a/Namo.Plugin.InPlayerEpisodePreview/Namo.Plugin.InPlayerEpisodePreview.csproj
+++ b/Namo.Plugin.InPlayerEpisodePreview/Namo.Plugin.InPlayerEpisodePreview.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.9.11" />
-    <PackageReference Include="Jellyfin.Model" Version="10.9.11" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.10.0" />
+    <PackageReference Include="Jellyfin.Model" Version="10.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Namo.Plugin.InPlayerEpisodePreview/Namo.Plugin.InPlayerEpisodePreview.csproj
+++ b/Namo.Plugin.InPlayerEpisodePreview/Namo.Plugin.InPlayerEpisodePreview.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <AssemblyVersion>1.3.0.0</AssemblyVersion>
-    <FileVersion>1.3.0.0</FileVersion>
-    <Version>1.3.0.0</Version>
+    <AssemblyVersion>1.3.1.0</AssemblyVersion>
+    <FileVersion>1.3.1.0</FileVersion>
+    <Version>1.3.1.0</Version>
     <LangVersion>12</LangVersion>
   </PropertyGroup>
 

--- a/Namo.Plugin.InPlayerEpisodePreview/build.bat
+++ b/Namo.Plugin.InPlayerEpisodePreview/build.bat
@@ -3,7 +3,7 @@
 REM Hash tool: https://emn178.github.io/online-tools/md5_checksum.html
 
 REM Flags
-set version="1.3.0.0"
+set version="1.3.1.0"
 
 REM Create build directory
 if not exist ".build" mkdir .build

--- a/manifest.json
+++ b/manifest.json
@@ -94,6 +94,14 @@
                 "sourceUrl": "https://github.com/Namo2/InPlayerEpisodePreview/releases/download/v1.3.0.0/InPlayerEpisodePreview-1.3.0.0-server.zip",
                 "checksum": "21e3583d4bb83f3bf61590d0b9dff2d6",
                 "timestamp": "2024-10-26T12:56:00Z"
+            },
+            {
+                "version": "1.3.1.0",
+                "changelog": "Fixes issues with the new Jellyfin 10.10.0 release",
+                "targetAbi": "10.10.0.0",
+                "sourceUrl": "https://github.com/Namo2/InPlayerEpisodePreview/releases/download/v1.3.1.0/InPlayerEpisodePreview-1.3.1.0-server.zip",
+                "checksum": "d47bf5f61c4e6abf7d1498cdff91874c",
+                "timestamp": "2024-10-26T18:34:00Z"
             }
         ]
     }


### PR DESCRIPTION
Fixed a problem where the activeMediaSourceId got fetched incorrectly with the new Jellyfin 10.10.0 release.

PlaybackInfo isn't captured by the internal fetch event now.
As activeMediaSourceId the id of the last sent single item will be used